### PR TITLE
allow for dao transfer of governables 

### DIFF
--- a/contracts/DAO/ProposalFactory.sol
+++ b/contracts/DAO/ProposalFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 import "../facades/LimboDAOLike.sol";
 import "./Governable.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "../openzeppelin/Ownable.sol";
 
 // import "hardhat/console.sol";
 

--- a/contracts/Flan.sol
+++ b/contracts/Flan.sol
@@ -61,12 +61,12 @@ contract Flan is ERC677("Flan", "FLN"), Governable {
     ///@param recipient address to receive flan
     ///@param amount amount of flan to be minted 
     function mint(address recipient, uint256 amount) public returns (bool) {
-        uint256 allowance = mintAllowance[_msgSender()];
+        uint256 allowance = mintAllowance[msg.sender];
         require(
-            _msgSender() == owner() || allowance >= amount,
+            msg.sender == owner() || allowance >= amount,
             "Flan: Mint allowance exceeded"
         );
-        approvedMint(recipient, amount, _msgSender(), allowance);
+        approvedMint(recipient, amount, msg.sender, allowance);
         return true;
     }
 

--- a/contracts/openzeppelin/ERC20Burnable.sol
+++ b/contracts/openzeppelin/ERC20Burnable.sol
@@ -6,7 +6,7 @@
 
 pragma solidity 0.8.13;
 import "./IERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "./Ownable.sol";
 // import "hardhat/console.sol";
 
 // import "hardhat/console.sol";
@@ -66,7 +66,7 @@ interface IERC20Metadata is IERC20 {
  * functions have been added to mitigate the well-known issues around setting
  * allowances. See {IERC20-approve}.
  */
-contract ERC20 is Context, IERC20, IERC20Metadata {
+contract ERC20 is IERC20, IERC20Metadata {
   mapping(address => uint256) internal _balances;
 
   mapping(address => mapping(address => uint256)) internal _allowances;
@@ -145,7 +145,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
    * - the caller must have a balance of at least `amount`.
    */
   function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
-    _transfer(_msgSender(), recipient, amount);
+    _transfer(msg.sender, recipient, amount);
     return true;
   }
 
@@ -164,7 +164,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
    * - `spender` cannot be the zero address.
    */
   function approve(address spender, uint256 amount) public virtual override returns (bool) {
-    _approve(_msgSender(), spender, amount);
+    _approve(msg.sender, spender, amount);
     return true;
   }
 
@@ -187,10 +187,10 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
     uint256 amount
   ) public virtual override returns (bool) {
     _transfer(sender, recipient, amount);
-    uint256 currentAllowance = _allowances[sender][_msgSender()];
+    uint256 currentAllowance = _allowances[sender][msg.sender];
  
     require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
-    _approve(sender, _msgSender(), currentAllowance - amount);
+    _approve(sender, msg.sender, currentAllowance - amount);
     return true;
   }
 
@@ -207,7 +207,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
    * - `spender` cannot be the zero address.
    */
   function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
-    _approve(_msgSender(), spender, _allowances[_msgSender()][spender] + addedValue);
+    _approve(msg.sender, spender, _allowances[msg.sender][spender] + addedValue);
     return true;
   }
 
@@ -226,9 +226,9 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
    * `subtractedValue`.
    */
   function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
-    uint256 currentAllowance = _allowances[_msgSender()][spender];
+    uint256 currentAllowance = _allowances[msg.sender][spender];
     require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
-    _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+    _approve(msg.sender, spender, currentAllowance - subtractedValue);
 
     return true;
   }
@@ -336,14 +336,14 @@ contract ERC20 is Context, IERC20, IERC20Metadata {
  * tokens and those that they have an allowance for, in a way that can be
  * recognized off-chain (via event analysis).
  */
-abstract contract ERC20Burnable is Context, ERC20 {
+abstract contract ERC20Burnable is ERC20 {
   /**
    * @dev Destroys `amount` tokens from the caller.
    *
    * See {ERC20-_burn}.
    */
   function burn(uint256 amount) public virtual returns (bool) {
-    _burn(_msgSender(), amount);
+    _burn(msg.sender, amount);
     return true;
   }
 
@@ -359,9 +359,9 @@ abstract contract ERC20Burnable is Context, ERC20 {
    * `amount`.
    */
   function burnFrom(address account, uint256 amount) public virtual {
-    uint256 currentAllowance = allowance(account, _msgSender());
+    uint256 currentAllowance = allowance(account, msg.sender);
     require(currentAllowance >= amount, "ERC20: burn amount exceeds allowance");
-    _approve(account, _msgSender(), currentAllowance - amount);
+    _approve(account, msg.sender, currentAllowance - amount);
     _burn(account, amount);
   }
 }

--- a/contracts/openzeppelin/ERC677.sol
+++ b/contracts/openzeppelin/ERC677.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.13;
+import "./Ownable.sol";
 import "./ERC20Burnable.sol";
 import "./IERC677Receiver.sol";
 
@@ -25,7 +26,7 @@ contract ERC677 is ERC20Burnable, Ownable {
         uint256 _value,
         bytes memory _data
     ) public returns (bool success) {
-        _transfer(_msgSender(), _to, _value);
+        _transfer(msg.sender, _to, _value);
         if (isContract(_to)) {
             contractFallback(_to, _value, _data);
         }
@@ -38,7 +39,7 @@ contract ERC677 is ERC20Burnable, Ownable {
         bytes memory _data
     ) private {
         IERC677Receiver receiver = IERC677Receiver(_to);
-        receiver.onTokenTransfer(_msgSender(), _value, _data);
+        receiver.onTokenTransfer(msg.sender, _value, _data);
     }
 
     function isContract(address _addr) private view returns (bool hasCode) {

--- a/contracts/openzeppelin/Ownable.sol
+++ b/contracts/openzeppelin/Ownable.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import "../periphery/Errors.sol";
+
+abstract contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor() {
+        _transferOwnership(msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        if(owner()!=msg.sender){
+            revert OnlyOwner(msg.sender, owner());
+        }
+        _;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+       if(newOwner==address(0)){
+           revert TransferToZeroAddress();
+       }
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}

--- a/contracts/periphery/Errors.sol
+++ b/contracts/periphery/Errors.sol
@@ -31,3 +31,7 @@ error FateToFlanConversionDisabled();
 error UniswapV2FactoryMismatch (address pairFactory,address trueFactory);
 error InvalidVoteCast(int fateCast, int currentProposalFate);
 error VotingPeriodOver (uint blockTime,uint proposalStartTime,uint votingDuration);
+
+//OWNABLE
+error OnlyOwner(address caller, address owner);
+error TransferToZeroAddress();

--- a/contracts/testing/MockFOTToken.sol
+++ b/contracts/testing/MockFOTToken.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 import "../openzeppelin/ERC20Burnable.sol";
 
-contract MockFOTToken is Context, IERC20, IERC20Metadata {
+contract MockFOTToken is IERC20, IERC20Metadata {
 
     uint transferFee = 0;//0-1000
     mapping(address => uint256) internal _balances;
@@ -96,7 +96,7 @@ contract MockFOTToken is Context, IERC20, IERC20Metadata {
         override
         returns (bool)
     {
-        _transfer(_msgSender(), recipient, amount);
+        _transfer(msg.sender, recipient, amount);
         return true;
     }
 
@@ -126,7 +126,7 @@ contract MockFOTToken is Context, IERC20, IERC20Metadata {
         override
         returns (bool)
     {
-        _approve(_msgSender(), spender, amount);
+        _approve(msg.sender, spender, amount);
         return true;
     }
 
@@ -150,12 +150,12 @@ contract MockFOTToken is Context, IERC20, IERC20Metadata {
     ) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
 
-        uint256 currentAllowance = _allowances[sender][_msgSender()];
+        uint256 currentAllowance = _allowances[sender][msg.sender];
         require(
             currentAllowance >= amount,
             "ERC20: transfer amount exceeds allowance"
         );
-        _approve(sender, _msgSender(), currentAllowance - amount);
+        _approve(sender, msg.sender, currentAllowance - amount);
 
         return true;
     }
@@ -178,9 +178,9 @@ contract MockFOTToken is Context, IERC20, IERC20Metadata {
         returns (bool)
     {
         _approve(
-            _msgSender(),
+            msg.sender,
             spender,
-            _allowances[_msgSender()][spender] + addedValue
+            _allowances[msg.sender][spender] + addedValue
         );
         return true;
     }
@@ -204,12 +204,12 @@ contract MockFOTToken is Context, IERC20, IERC20Metadata {
         virtual
         returns (bool)
     {
-        uint256 currentAllowance = _allowances[_msgSender()][spender];
+        uint256 currentAllowance = _allowances[msg.sender][spender];
         require(
             currentAllowance >= subtractedValue,
             "ERC20: decreased allowance below zero"
         );
-        _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+        _approve(msg.sender, spender, currentAllowance - subtractedValue);
 
         return true;
     }


### PR DESCRIPTION
https://github.com/code-423n4/2022-01-behodler-findings/issues/86

It wasn't actually possible to transfer DAO ownership of governable objects beyond Limbo and Flan. Although this was intentional, it's not super future proof.

The DAO and Limbo kept running up against max deployment size. One aspect bloating the size was openzeppelin's context abstract contract. The ownable object was simplified to have this removed. This means we can't use the gas relay network but in all likelihood, Limbo is going to be redeployed across L2s, shards etc and not rely on L1 magic to survive high gas costs.