### PR TITLE
Audit fixes

### DIFF
--- a/ABIs/AMMHelper.json
+++ b/ABIs/AMMHelper.json
@@ -1,5 +1,4 @@
 [
-  "function buyFlanAndBurn(address,uint256,address)",
   "function minAPY_to_FPS(uint256,uint256) pure returns (uint256)",
   "function stabilizeFlan(uint256) returns (uint256)"
 ]

--- a/ABIs/ClaimSecondaryRewardsProposal.json
+++ b/ABIs/ClaimSecondaryRewardsProposal.json
@@ -1,0 +1,15 @@
+[
+  "constructor(address)",
+  "error ExecutionFailed()",
+  "error InsufficinetFunds(uint256,uint256)",
+  "error NotAContract(address)",
+  "error OnlyFactoryOrDAO(address,address)",
+  "error OperationFailure()",
+  "error ProposalLocked(address)",
+  "function description() view returns (string)",
+  "function locked() view returns (bool)",
+  "function orchestrateExecute()",
+  "function parameterize(address,address)",
+  "function params() view returns (address, address)",
+  "function setLocked(bool)"
+]

--- a/ABIs/LimboLike.json
+++ b/ABIs/LimboLike.json
@@ -1,4 +1,5 @@
 [
+  "function claimSecondaryRewards(address)",
   "function configureSoul(address,uint256,uint256,uint256,uint256,uint256)",
   "function latestIndex(address) view returns (uint256)",
   "function souls(address,uint256) view returns (uint256, uint256, uint256, uint256, uint256, uint256)",

--- a/ABIs/SoulReader.json
+++ b/ABIs/SoulReader.json
@@ -3,5 +3,6 @@
   "function ExpectedCrossingBonus(address,address,address) view returns (uint256)",
   "function ExpectedCrossingBonusRate(address,address,address) view returns (uint256)",
   "function GetPendingReward(address,address,address) view returns (uint256)",
-  "function SoulStats(address,address) view returns (uint256, uint256, uint256)"
+  "function SoulStats(address,address) view returns (uint256, uint256, uint256)",
+  "function getCurrentSoulState(address,address) view returns (uint256)"
 ]

--- a/ABIs/UniswapHelper.json
+++ b/ABIs/UniswapHelper.json
@@ -10,7 +10,6 @@
   "error PriceOvershootTooHigh(uint8)",
   "function DAO() view returns (address)",
   "function blackHole() view returns (address)",
-  "function buyFlanAndBurn(address,uint256,address)",
   "function configure(address,address,address,uint8,uint8,address)",
   "function configured() view returns (bool)",
   "function endConfiguration(address)",

--- a/ABIs/VanillaProxy.json
+++ b/ABIs/VanillaProxy.json
@@ -21,7 +21,6 @@
   "function initialRedeemRate() view returns (uint256)",
   "function migrateBaseReserveToNewProxy(address)",
   "function mint(address,address,uint256) returns (uint256)",
-  "function mintCustom(address,address,uint256) returns (uint256)",
   "function name() view returns (string)",
   "function proxyRegistry() view returns (address)",
   "function redeem(address,address,uint256) returns (uint256)",

--- a/contracts/DAO/ProposalFactory.sol
+++ b/contracts/DAO/ProposalFactory.sol
@@ -29,6 +29,7 @@ abstract contract Proposal {
     _;
   }
 
+  //decorate parameterization functions with this to prevent MEV calibration attacks
   modifier lockUntilComplete() {
     if(locked){
       revert ProposalLocked(address(this));

--- a/contracts/DAO/Proposals/ClaimSecondaryRewardsProposal.sol
+++ b/contracts/DAO/Proposals/ClaimSecondaryRewardsProposal.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.16;
+import "../ProposalFactory.sol";
+import "../../facades/LimboLike.sol";
+import "../../openzeppelin/SafeERC20.sol";
+
+contract ClaimSecondaryRewardsProposal is Proposal {
+  using SafeERC20 for IERC20;
+
+  constructor(address _dao) Proposal(_dao, "ClaimSecondaryRewardProposal") {}
+
+  struct Parameters {
+    address token;
+    address destination;
+  }
+
+  Parameters public params;
+
+  function parameterize(address token, address destination) public lockUntilComplete {
+    params.token = token;
+    params.destination = destination;
+  }
+
+  function execute() internal override returns (bool) {
+    (address _limbo, , , , , , ) = DAO.domainConfig();
+    LimboLike limbo = LimboLike(_limbo);
+    
+    //claim secondary rewards from Limbo
+    address token = params.token;
+    uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+    limbo.claimSecondaryRewards(token);
+    uint256 amount = IERC20(token).balanceOf(address(this)) - balanceBefore;
+
+    //transfer out of proposal to correct address
+    IERC20(token).safeTransfer(params.destination, amount);
+    return true;
+  }
+}

--- a/contracts/DAO/Proposals/ConfigureFlashGovernanceProposal.sol
+++ b/contracts/DAO/Proposals/ConfigureFlashGovernanceProposal.sol
@@ -6,7 +6,7 @@ import "../../facades/FlashGovernanceArbiterLike.sol";
 
 contract ConfigureFlashGovernanceProposal is Proposal {
   struct ParameterSet {
- address asset;
+    address asset;
     uint256 amount;
     uint256 unlockTime;
     bool assetBurnable;
@@ -16,10 +16,12 @@ contract ConfigureFlashGovernanceProposal is Proposal {
 
   constructor(address dao, string memory _description) Proposal(dao, description) {}
 
-  function parameterize(address asset,
+  function parameterize(
+    address asset,
     uint256 amount,
     uint256 unlockTime,
-    bool assetBurnable) public lockUntilComplete {
+    bool assetBurnable
+  ) public lockUntilComplete {
     params.asset = asset;
     params.amount = amount;
     params.unlockTime = unlockTime;

--- a/contracts/TokenProxies/TokenProxyBase.sol
+++ b/contracts/TokenProxies/TokenProxyBase.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.16;
 import "../openzeppelin/SafeERC20.sol";
 import "../openzeppelin/ERC20Burnable.sol";
+import "hardhat/console.sol";
 
 ///@dev Only use this directly for perpetual tokens. For threshold tokens, use BehodlerTokenProxy
 contract TokenProxyBase is ERC20 {
@@ -42,6 +43,7 @@ contract TokenProxyBase is ERC20 {
     uint256 amount
   ) internal returns (uint256 proxy) {
     uint256 _redeemRate = (redeemRate() * R_amp) / initialRedeemRate;
+    console.log('CONTRACT: redeemRate %d',_redeemRate);
     uint256 balanceBefore = IERC20(baseToken).balanceOf(address(this));
 
     IERC20(baseToken).safeTransferFrom(baseSource, address(this), amount);
@@ -55,7 +57,7 @@ contract TokenProxyBase is ERC20 {
     address proxyRecipient,
     address baseSource,
     uint256 amount
-  ) public returns (uint256 proxy) {
+  ) public virtual returns (uint256 proxy) {
     uint256 _redeemRate = redeemRate();
     uint256 balanceBefore = IERC20(baseToken).balanceOf(address(this));
 

--- a/contracts/UniswapHelper.sol
+++ b/contracts/UniswapHelper.sol
@@ -213,30 +213,6 @@ contract UniswapHelper is Governable, AMMHelper {
     fps = returnOnThreshold / (year);
   }
 
-  ///@notice Buys Flan with a specified token, apportions 1% of the purchased Flan to the caller and burns the rest.
-  ///@param inputToken The token used to buy Flan
-  ///@param amount amount of input token used to buy Flan
-  ///@param recipient receives 1% of Flan purchased as an incentive to call this function regularly
-  ///@dev Assumes a pair for Flan/InputToken exists on Uniswap
-  function buyFlanAndBurn(
-    address inputToken,
-    uint256 amount,
-    address recipient
-  ) public override {
-    address pair = VARS.factory.getPair(inputToken, VARS.flan);
-    uint256 flanBalance = IERC20(VARS.flan).balanceOf(pair);
-    uint256 inputBalance = IERC20(inputToken).balanceOf(pair);
-
-    uint256 amountOut = getAmountOut(amount, inputBalance, flanBalance);
-    uint256 amount0Out = inputToken < VARS.flan ? 0 : amountOut;
-    uint256 amount1Out = inputToken < VARS.flan ? amountOut : 0;
-    IERC20(inputToken).transfer(pair, amount);
-    IUniswapV2Pair(pair).swap(amount0Out, amount1Out, address(this), "");
-    uint256 reward = (amountOut / 100);
-    ERC20Burnable(VARS.flan).transfer(recipient, reward);
-    ERC20Burnable(VARS.flan).burn(amountOut - reward);
-  }
-
   function getAmountOut(
     uint256 amountIn,
     uint256 reserveIn,

--- a/contracts/facades/AMMHelper.sol
+++ b/contracts/facades/AMMHelper.sol
@@ -12,10 +12,4 @@ abstract contract AMMHelper {
         pure
         virtual
         returns (uint256 fps);
-
-    function buyFlanAndBurn(
-        address inputToken,
-        uint256 amount,
-        address recipient
-    ) public virtual;
 }

--- a/contracts/facades/LimboLike.sol
+++ b/contracts/facades/LimboLike.sol
@@ -71,4 +71,6 @@ abstract contract LimboLike {
     uint256 amount,
     address holder
   ) public virtual;
+
+  function claimSecondaryRewards(address token) public virtual;
 }

--- a/contracts/periphery/SoulReader.sol
+++ b/contracts/periphery/SoulReader.sol
@@ -30,6 +30,16 @@ contract SoulReader {
    *@param token the token contract address
    *@param _limbo the limbo contract address
    */
+  function getCurrentSoulState(address token, address _limbo) public view returns (uint256 state) {
+    LimboLike limbo = getLimbo(_limbo);
+    uint256 latestIndex = limbo.latestIndex(token);
+    (, , , , state, ) = limbo.souls(token, latestIndex);
+  }
+
+  /**
+   *@param token the token contract address
+   *@param _limbo the limbo contract address
+   */
   function SoulStats(address token, address _limbo)
     public
     view

--- a/contracts/testing/VanillaProxy.sol
+++ b/contracts/testing/VanillaProxy.sol
@@ -19,11 +19,11 @@ contract VanillaProxy is TokenProxyBase {
     R_amp = _R_amp * 10**15;
   }
 
-  function mintCustom(
+  function mint(
     address proxyRecipient,
     address baseSource,
     uint256 amount
-  ) public returns (uint) {
+  ) public override returns (uint) {
     return mint(R_amp, proxyRecipient, baseSource, amount);
   }
 

--- a/documentation/Limbo/claimSecondaryRewards.plantUML
+++ b/documentation/Limbo/claimSecondaryRewards.plantUML
@@ -4,7 +4,7 @@
 start
 :Limbo.claimSecondaryRewards(address token);
 partition yoghurt "transaction"{
-    if(state is calibration or crossed over) then (yes)
+    if(state is unset or crossed over) then (yes)
         :get balance of token on Limbo;
         :AMMHelper.buyFlanAndBurn();
         partition #LightGreen "UniswapHelper"{

--- a/test/limbo.test.ts
+++ b/test/limbo.test.ts
@@ -1926,71 +1926,7 @@ describe.only("Limbo", function () {
       await lodgeAndExecuteClaimSecondaryRewards(proposal, sushi, this.eye, this.limboDAO, this.proposalFactory,true)
     })
   }
-
-
-  // it("t-27.2 waitingToCrossover tokens cannot be claimed as secondary rewards", async function () {
-  //   throw "not implemented";
-  // })
-
-
-  // it("t-27.3 waitingToCrossover tokens cannot be claimed as secondary rewards", async function () {
-  //   throw "not implemented";
-  // })
-
-  // it("t-27.4 crossedOver tokens cannot be claimed as secondary rewards", async function () {
-  //   throw "not implemented";
-  // })
-
-  it("t-27. protocol token buy buck works", async function () {
-    const sushi = await this.TokenFactory.deploy("Sushi", "Sushi");
-    await sushi.mint("10000");
-    await sushi.transfer(this.limbo.address, "10000");
-    const UniPair = await ethers.getContractFactory("UniswapV2Pair");
-
-    await this.uniswapFactory.createPair(sushi.address, this.flan.address);
-
-    const pairAddress = await this.uniswapFactory.getPair(this.flan.address, sushi.address);
-
-    await sushi.mint("1000000000");
-    await sushi.transfer(pairAddress, "1000000000");
-    await this.flan.mint(pairAddress, "80000000000");
-    const scxFlanPair = await UniPair.attach(pairAddress);
-    await scxFlanPair.mint(owner.address);
-
-    let result = await executionResult(this.uniOracle.RegisterPair(pairAddress, 1));
-    expect(result.success).to.equal(true, result.error);
-
-    result = await executionResult(
-      this.uniswapHelper.configure(
-        this.limbo.address,
-        this.mockBehodler.address,
-        this.flan.address,
-        20,
-        0,
-        this.uniOracle.address
-      )
-    );
-    expect(result.success).to.equal(true, result.error);
-
-    const flanBalanceBefore = await this.flan.balanceOf(owner.address);
-    await sushi.approve(this.limbo.address, "10000000000");
-    result = await executionResult(this.limbo.claimSecondaryRewards(sushi.address));
-    expect(result.success).to.equal(true, result.error);
-
-    const flanBalanceAfter = await this.flan.balanceOf(owner.address);
-    const sushibalanceOnLimboAfter = await sushi.balanceOf(this.limbo.address);
-
-    expect(flanBalanceAfter.gt(flanBalanceBefore)).to.be.true;
-    expect(sushibalanceOnLimboAfter).to.equal(0);
-
-    await this.limbo.configureSoul(sushi.address, 10000000, 1, 1, 0, 10000000);
-
-    await sushi.mint("10000");
-    await sushi.transfer(this.limbo.address, "10000");
-
-    await expect(this.limbo.claimSecondaryRewards(sushi.address)).to.be.revertedWith("TokenAccountedFor");
-  });
-
+  
   it("t-28. flash governance tolerance enforced for flash loan but not successful proposals or unconfigured", async function () {
     await this.flashGovernance.configureSecurityParameters(10, 100, 3);
 

--- a/test/limbo.test.ts
+++ b/test/limbo.test.ts
@@ -1,5 +1,5 @@
 import { ContractReceipt } from "ethers";
-import { assertLog, executionResult, numberClose, queryChain } from "./helpers";
+import { assertLog, deploy, executionResult, numberClose, queryChain } from "./helpers";
 
 const { expect, assert } = require("chai");
 const { ethers, network } = require("hardhat");
@@ -216,7 +216,7 @@ describe.only("Limbo", function () {
     await this.limboDAO.makeLive();
 
     const SoulReaderFactory = await ethers.getContractFactory("SoulReader");
-    this.soulReader = await SoulReaderFactory.deploy();
+    this.soulReader = await SoulReaderFactory.deploy() as Types.SoulReader;
 
     const UniswapHelperFactory = await ethers.getContractFactory("UniswapHelper");
     this.uniswapHelper = await UniswapHelperFactory.deploy(this.limbo.address, this.limboDAO.address);
@@ -999,7 +999,7 @@ describe.only("Limbo", function () {
       this.aave.address, //token
       10000000, //threshold
       1, //type
-      0, //state = calibration
+      0, //state = unset
       0, //index
       10 //fps
     );
@@ -1510,7 +1510,7 @@ describe.only("Limbo", function () {
 
     const ratio2 = flanBalanceAfterThirdMigrate.mul(10000).div(scxBalanceOfPairAfterThirdMigrate);
 
-    expect(numberClose(ratio2, "23687384")).to.equal(true,ratio2);
+    expect(numberClose(ratio2, "23687384")).to.equal(true, ratio2);
   });
 
   it("t-23. any whitelisted contract can mint flan", async function () {
@@ -1833,6 +1833,113 @@ describe.only("Limbo", function () {
     expect(poolDetails[3]).to.equal(1); //soul type = migration
     expect(poolDetails[5]).to.equal("41222729578893962"); //fps
   });
+
+
+  async function deployClaimSecondaryRewardsProposal(limboDAO: Types.LimboDAO) {
+    const claimSecondaryRewardsProposalFactory = await ethers.getContractFactory("ClaimSecondaryRewardsProposal")
+    let claimSecondaryRewardsProposal = await deploy<Types.ClaimSecondaryRewardsProposal>(
+      claimSecondaryRewardsProposalFactory, limboDAO.address
+    );
+    return claimSecondaryRewardsProposal
+  }
+
+  async function lodgeAndExecuteClaimSecondaryRewards(claimSecondaryRewardsProposal: Types.ClaimSecondaryRewardsProposal, token: Types.MockToken, eye: Types.MockToken, limboDAO: Types.LimboDAO,
+    proposalFactory: Types.ProposalFactory,  expectError:boolean) {
+
+    //paramterize proposal
+    await claimSecondaryRewardsProposal.parameterize(token.address, owner.address)
+
+
+    //whitelist proposal on LimboDAO
+    await toggleWhiteList(claimSecondaryRewardsProposal.address)
+
+    //acquire enough fate to lodge and vote on proposal
+    const proposalConfig = await limboDAO.proposalConfig();
+    const requiredFate = proposalConfig[1].mul(2);
+    await eye.approve(limboDAO.address, requiredFate);
+    await eye.mint(requiredFate);
+    await limboDAO.burnAsset(eye.address, requiredFate, false);
+
+    //lodge proposal
+  
+   
+    await proposalFactory.lodgeProposal(claimSecondaryRewardsProposal.address);
+    //vote yes on proposal
+    await limboDAO.vote(claimSecondaryRewardsProposal.address, 1000);
+
+    //time travel to when voting period has ended
+    await advanceTime(6048010);
+
+    if(expectError){
+      await expect(limboDAO.executeCurrentProposal())
+      .to.emit(limboDAO, "proposalExecuted")
+      .withArgs(claimSecondaryRewardsProposal.address, false);
+    }
+    //execute proposal. Owner should get 10000 sushi
+    await limboDAO.executeCurrentProposal();
+
+
+  }
+
+  it("t-27.1 Only a proposal can withdraw secondary rewards", async function () {
+
+
+    //create unlisted token and send to limbo
+    const sushi = await this.TokenFactory.deploy("Sushi", "Sushi");
+    await sushi.mint("10000");
+    await sushi.transfer(this.limbo.address, "10000");
+
+    //assert token is in unset state on Limbo.
+    const soulReader: Types.SoulReader = this.soulReader as Types.SoulReader
+    let soulState = (await soulReader.getCurrentSoulState(sushi.address, this.limbo.address)).toNumber()
+    expect(soulState).to.equal(0)
+
+    //store owner balance before withdrawal
+    const ownerBalanceBefore = await sushi.balanceOf(owner.address)
+    const limboBalanceBefore = await sushi.balanceOf(this.limbo.address)
+
+    let proposal = await deployClaimSecondaryRewardsProposal(this.limboDAO)
+    await lodgeAndExecuteClaimSecondaryRewards(proposal, sushi, this.eye, this.limboDAO, this.proposalFactory,false)
+
+    const ownerBalanceAfter = await sushi.balanceOf(owner.address)
+    const limboBalanceAfter = await sushi.balanceOf(this.limbo.address)
+
+    //assert that Limbo has zero balance and owner has an increase of 10000
+    expect(ownerBalanceAfter.sub(ownerBalanceBefore).toNumber()).to.equal(10000)
+    expect(limboBalanceAfter.toNumber()).to.equal(0)
+    expect(limboBalanceBefore.toNumber()).to.equal(10000)
+  })
+
+  for (let i = 1; i < 4; i++) {
+
+
+    it("t-27.2 only unset tokens can be claimed as secondary rewards", async function () {
+      //create new token and list it on Behodler for staking
+      const sushi = await this.TokenFactory.deploy("Sushi", "Sushi");
+      await sushi.mint("10000");
+      await sushi.transfer(this.limbo.address, "10000");
+
+      await this.limbo.configureSoul(sushi.address, 10000000, 1, i, 0, 10000000);
+
+      let proposal = await deployClaimSecondaryRewardsProposal(this.limboDAO)
+      console.log('proposal: ' + proposal.address)
+      await lodgeAndExecuteClaimSecondaryRewards(proposal, sushi, this.eye, this.limboDAO, this.proposalFactory,true)
+    })
+  }
+
+
+  // it("t-27.2 waitingToCrossover tokens cannot be claimed as secondary rewards", async function () {
+  //   throw "not implemented";
+  // })
+
+
+  // it("t-27.3 waitingToCrossover tokens cannot be claimed as secondary rewards", async function () {
+  //   throw "not implemented";
+  // })
+
+  // it("t-27.4 crossedOver tokens cannot be claimed as secondary rewards", async function () {
+  //   throw "not implemented";
+  // })
 
   it("t-27. protocol token buy buck works", async function () {
     const sushi = await this.TokenFactory.deploy("Sushi", "Sushi");

--- a/test/proxy/cliffFace.test.ts
+++ b/test/proxy/cliffFace.test.ts
@@ -278,7 +278,7 @@ describe("cliffFace proxy test", function () {
     CliffFace = "CliffFace",
   }
 
-  const AMMTypes = [AMMType.UniswapPair, AMMType.Behodler, AMMType.CliffFace];
+  const AMMTypes = [ AMMType.Behodler, AMMType.CliffFace];
   AMMTypes.forEach((amm: AMMType) => {
     let description = `${amm.toString()} BENCHMARK: `;
     switch (amm) {

--- a/test/proxy/tokenProxyBase.test.ts
+++ b/test/proxy/tokenProxyBase.test.ts
@@ -375,7 +375,6 @@ describe("token proxy test", function () {
     expect(redeemRateAfter).to.equal(SET.ONE);
   });
 
-  //TODO: failing
   it("t10. changing R_amp affects marginal and average redeem rate predictably", async function () {
     await SET.RebaseProxy.mint(SET.owner.address, SET.owner.address, SET.ONE);
 

--- a/test/proxy/tokenProxyBase.test.ts
+++ b/test/proxy/tokenProxyBase.test.ts
@@ -375,6 +375,7 @@ describe("token proxy test", function () {
     expect(redeemRateAfter).to.equal(SET.ONE);
   });
 
+  //TODO: failing
   it("t10. changing R_amp affects marginal and average redeem rate predictably", async function () {
     await SET.RebaseProxy.mint(SET.owner.address, SET.owner.address, SET.ONE);
 


### PR DESCRIPTION
# Problems were identified in WatchPug audit with ClaimSecondaryRewards
[WP-C1] Attacker can steal unstaking tokens from the contract
[WP-M6] Attacker can sandwich attack claimSecondaryRewards() and get a larger portion of the "SecondaryRewards"

Previously the claimSecondaryRewards function relied on tokens being listed on Uniswap. Using live uniswap prices is subject to MEV attacks. Secondly, the SoulState calibration had ambiguous meaning. 

## Fixes
1. SoulState.calibration renamed to unset for tokens that have never been listed
2. Removal of AMMFlanBuyBack function from UniswapHelper
3. ClaimSecondaryRewards can now claim any unset token and can only be called by a successful proposal
4. A generic claim proposal was created and tested: secondary rewards can only be claimed for unset tokens by a governance proposal