### PR TITLE
wp-h5

### DIFF
--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,10 @@
 import { Result } from "@ethersproject/abi/lib/interface";
 import { Contract, ContractFactory, Event } from "ethers";
-export async function executionResult(transaction): Promise<{ success: boolean; error: string }> {
+export interface IExecutionResult {
+  success: boolean; error: string
+}
+export interface IQueryResult { success: boolean; error: string; result: any }
+export async function executionResult(transaction): Promise<IExecutionResult> {
   try {
     await transaction;
     return { success: true, error: "" };
@@ -9,21 +13,23 @@ export async function executionResult(transaction): Promise<{ success: boolean; 
   }
 }
 
-export const queryChain = async (query): Promise<{ success: boolean; error: string; result: any }> => {
+export const queryChain = async (query): Promise<IQueryResult> => {
   let result;
   try {
     result = await query;
-    return { success: true, error: "", result };
+    return { success: true, error: "", result};
   } catch (e) {
     return { success: false, error: e as string, result: null };
   }
 };
 
-export const numberClose = (actual, expected) => {
+export const numberClose = (actual, expected, range?:bigint) => {
+  range  = range || 20n
   let expectedBig = BigInt(expected.toString());
   const actualBig = BigInt(actual.toString());
-  const lower = (expectedBig / 100n) * 80n;
-  const higher = (expectedBig * 120n) / 100n;
+  
+  const lower = (expectedBig / (80n + range)) * 80n;
+  const higher = (expectedBig * (100n+range)) / 100n;
   const condition = lower < actualBig && higher > actualBig;
   if (!condition) {
     const perc = parseFloat(`${(actualBig * 10000n) / expectedBig}`) / 10000;


### PR DESCRIPTION
It was found in the WatchPug audit that staking EYE multiple times with the same amount was not idempotent. In particular, an attacker could inflate their Fate balance by just calling stake on the same EYE balance repeatedly. 

This PR fixes that bug and normalizes the calculation for LP tokens to conform with the fix. Now clout is the square root number and fate per day is clout scaled by 1e9 to give it numbers comparable to standard ERC20 tokens for front end convenience.
 
Unit tests have been altered so that random numbers of call are made to stake both asset types where the random number is greater than 1.

Additional non-breaking changes: 
Minor gas optimization on reducing the number of SLOADs in the staking function and magic numbers have been replaced with constants.